### PR TITLE
fix_Insert_Request_without_inventory

### DIFF
--- a/src/main/java/com/croydon/service/implementation/RequestsWithoutInventoryImpl.java
+++ b/src/main/java/com/croydon/service/implementation/RequestsWithoutInventoryImpl.java
@@ -18,6 +18,8 @@ import com.croydon.model.entity.RequestsWithoutInventory;
 import com.croydon.service.IRequestsWithoutInventory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  *
@@ -30,6 +32,7 @@ public class RequestsWithoutInventoryImpl implements IRequestsWithoutInventory {
     private RequestsWithoutInventoryDao service;
     
     @Override
+   @Transactional(propagation = Propagation.REQUIRES_NEW)
     public RequestsWithoutInventory save(RequestsWithoutInventory requestsWithoutInventory) {
         return service.save(requestsWithoutInventory);
     }


### PR DESCRIPTION
 transacción independiente: Así, si la transacción principal hace rollback, la inserción en requests_without_inventory se mantiene.